### PR TITLE
Adding line to short_circuit_choices

### DIFF
--- a/modAutomaticDialogPicker/content/scripts/local/automaticDialogPicker/random_dialog_picker.ws
+++ b/modAutomaticDialogPicker/content/scripts/local/automaticDialogPicker/random_dialog_picker.ws
@@ -104,6 +104,9 @@ statemachine class MCM_RandomDialogPicker {
 
     // Family Matters: Let's do this.
     this.short_circuit_choices.PushBack(GetLocStringById(393189));
+
+    // Family Matters: Who'd you see? Describe her.
+    this.short_circuit_choices.PushBack(GetLocStringById(177966));
   }
 
   function isOptionalChoice(choice: SSceneChoice): bool {


### PR DESCRIPTION
When talking with fisherman in quest "Family Matters" there are this chooses:

- Girl who stayed with you - what happened to her?
- Who'd you see? Describe her. (optional)

Option choice is forceful on the kid in that scene. In my playthroughs I never choice that option. I think this should be up to the player to decide.